### PR TITLE
Debug log for decoded requests

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -73,6 +73,8 @@ func ControlHandler(cgroupRoot string) http.HandlerFunc {
 		response.Unit = request.Unit
 		response.Property = request.Property
 
+		slog.Debug("Decoded request", "unit", request.Unit, "property", request.Property.Name, "value", request.Property.Value)
+		
 		var newLimit int64
 		var fallback bool = false
 


### PR DESCRIPTION
This PR adds a debug log to print the decoded request. This makes it easier to see if the request from Arbiter actually is received by the cgroup-warden (helpful to debug network issues etc)